### PR TITLE
Allow 14-bit values to be specified as MSB:LSB

### DIFF
--- a/Source/ApplicationState.cpp
+++ b/Source/ApplicationState.cpp
@@ -537,7 +537,17 @@ uint8 ApplicationState::asDecOrHex7BitValue(String value)
 
 uint16 ApplicationState::asDecOrHex14BitValue(String value)
 {
-    return (uint16)limit14Bit(asDecOrHexIntValue(value));
+    int index = value.indexOfChar(':');
+    if (index == -1)
+    {
+        return (uint16)limit14Bit(asDecOrHexIntValue(value));
+    }
+    else
+    {
+        int msb = limit7Bit(asDecOrHexIntValue(value.substring(0, index)));
+        int lsb = limit7Bit(asDecOrHexIntValue(value.substring(index + 1)));
+        return (uint16)(msb * 128 + lsb);
+    }
 }
 
 int ApplicationState::asDecOrHexIntValue(String value)


### PR DESCRIPTION
Allow 14-bit values to be specified as a 7-bit MSB value and 7-bit LSB value separated by a colon, for easier use with devices whose documentation gives the MSB and LSB separately.